### PR TITLE
[Maintenance].github以下に変更があったときにktlintを実行しない

### DIFF
--- a/.github/workflows/actions-run-ktlint.yml
+++ b/.github/workflows/actions-run-ktlint.yml
@@ -2,6 +2,8 @@ name: Ktlint
 
 on:
   pull_request:
+    paths-ignore:
+      - ".github/**"
 
 jobs:
   build:


### PR DESCRIPTION
## マージの目的
.github以下に変更があったときにktlintを実行しないようにする

## 変更内容
- ktlintのworkflowファイルにpaths-ignoreを追加

## 確認内容
- .github以下に変更があった場合lintが走らなくなるように変更されていること

## 参考画像
- なくても良い
