### PR TITLE
[Feat]からのテーブルの表示とUI調節

### DIFF
--- a/app/src/main/java/com/example/timetable/model/source/DailyTables.kt
+++ b/app/src/main/java/com/example/timetable/model/source/DailyTables.kt
@@ -2,5 +2,5 @@ package com.example.timetable.model.source
 
 data class DailyTables(
     val week: String,
-    val subjects: List<Subject>,
+    val subjects: Map<Int, Subject?>,
 )

--- a/app/src/main/java/com/example/timetable/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/main/MainScreen.kt
@@ -3,6 +3,7 @@ package com.example.timetable.ui.main
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.example.timetable.ui.main.timeTable.BlankTable
 import com.example.timetable.ui.main.timeTable.TimeTable
 
@@ -10,9 +11,12 @@ import com.example.timetable.ui.main.timeTable.TimeTable
 fun MainScreen(
     modifier: Modifier = Modifier,
 ) {
+    val weeksHeight = 32.dp
+    val timesWidth = 24.dp
+
     Box(){
-        BlankTable(timeTable = MockTimeTable.timetable)
-        TimeTable(timeTable = MockTimeTable.timetable)
+        BlankTable(timeTable = MockTimeTable.timetable, weeksHeight = weeksHeight, timesWidth = timesWidth)
+        TimeTable(timeTable = MockTimeTable.timetable, weeksHeight = weeksHeight, timesWidth = timesWidth)
     }
 }
 

--- a/app/src/main/java/com/example/timetable/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/main/MainScreen.kt
@@ -14,10 +14,8 @@ fun MainScreen(
     val weeksHeight = 32.dp
     val timesWidth = 24.dp
 
-    Box(){
+    Box() {
         BlankTable(timeTable = MockTimeTable.timetable, weeksHeight = weeksHeight, timesWidth = timesWidth)
         TimeTable(timeTable = MockTimeTable.timetable, weeksHeight = weeksHeight, timesWidth = timesWidth)
     }
 }
-
-

--- a/app/src/main/java/com/example/timetable/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/main/MainScreen.kt
@@ -1,163 +1,19 @@
 package com.example.timetable.ui.main
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import com.example.timetable.model.source.DailyTables
-import com.example.timetable.model.source.Subject
+import com.example.timetable.ui.main.timeTable.BlankTable
+import com.example.timetable.ui.main.timeTable.TimeTable
 
 @Composable
 fun MainScreen(
     modifier: Modifier = Modifier,
 ) {
-    TimeTable(timeTable = MockTimeTable.timetable)
-}
-
-@Composable
-fun TimeTable(
-    modifier: Modifier = Modifier,
-    timeTable: List<DailyTables>,
-) {
-    val timesWidth = 20.dp
-    Column() {
-        // Top Row Display Weeks
-        Row(
-            modifier = modifier.fillMaxWidth(),
-        ) {
-            val tableWeight = 1f
-            Spacer(modifier = modifier.width(timesWidth))
-            timeTable.forEach { daily ->
-                Text(
-                    text = daily.week,
-                    modifier = modifier
-                        .weight(tableWeight)
-                        .border(
-                            width = 1.dp,
-                            color = Color.LightGray,
-                        ),
-                    textAlign = TextAlign.Center
-                    ,
-                )
-            }
-        }
-
-        // Display TimeTable
-        Row(
-            modifier = modifier.fillMaxWidth(),
-        ) {
-            Column(
-                modifier = modifier.width(timesWidth)
-                ,
-            ) {
-                for (i in 1..timeTable[0].subjects.size) {
-                    Text(
-                        text = i.toString(),
-                        modifier = modifier
-                            .fillMaxSize()
-                            .border(
-                                width = 1.dp,
-                                color = Color.LightGray,
-                            )
-                            .wrapContentHeight()
-                            .weight(.1f),
-                    )
-                }
-            }
-            Row(
-                modifier = modifier.background(
-                    shape = RoundedCornerShape(4.dp),
-                    color = MaterialTheme.colorScheme.background
-                )
-            ) {
-                timeTable.forEach { daily ->
-                    Box(modifier = modifier.weight(.1f)){
-                        BlankColumn()
-                        DailyColumn(dailySubject = daily.subjects)
-                    }
-                }
-            }
-        }
+    Box(){
+        BlankTable(timeTable = MockTimeTable.timetable)
+        TimeTable(timeTable = MockTimeTable.timetable)
     }
 }
 
-@Composable
-fun BlankColumn(
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier = modifier,
-    ) {
-        for(i in 1..5) {
-            BlackSubject(modifier = modifier.weight(.1f))
-        }
-    }
-}
 
-@Composable
-fun DailyColumn(
-    modifier: Modifier = Modifier,
-    dailySubject: Map<Int, Subject?>,
-) {
-    Column(
-        modifier = modifier,
-    ) {
-        dailySubject.forEach {
-            it.value.let {subject -> 
-                if (subject != null)SubjectCard(subject = subject, modifier = modifier.weight(.1f))
-                else Spacer(modifier = modifier.weight(.1f))
-            }
-        }
-    }
-}
-
-@Composable
-fun SubjectCard(
-    modifier: Modifier = Modifier,
-    subject: Subject,
-) {
-    Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(4.dp),
-    ) {
-        Column(
-            modifier = modifier
-                .padding(4.dp),
-        ) {
-            Text(text = subject.subjectName)
-            Text(text = subject.classRoom ?: "")
-            Text(text = subject.teacher ?: "")
-        }
-    }
-}
-
-@Composable
-fun BlackSubject(
-    modifier: Modifier = Modifier,
-) {
-    Box(
-        modifier = modifier
-            .fillMaxSize()
-            .border(
-                width = 1.dp,
-                color = Color.LightGray,
-            )
-    )
-}

--- a/app/src/main/java/com/example/timetable/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/main/MainScreen.kt
@@ -1,16 +1,23 @@
 package com.example.timetable.ui.main
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.example.timetable.model.source.DailyTables
@@ -39,8 +46,14 @@ fun TimeTable(
             timeTable.forEach { daily ->
                 Text(
                     text = daily.week,
-                    modifier = modifier.weight(tableWeight),
-                    textAlign = TextAlign.Center,
+                    modifier = modifier
+                        .weight(tableWeight)
+                        .border(
+                            width = 1.dp,
+                            color = Color.LightGray,
+                        ),
+                    textAlign = TextAlign.Center
+                    ,
                 )
             }
         }
@@ -50,20 +63,34 @@ fun TimeTable(
             modifier = modifier.fillMaxWidth(),
         ) {
             Column(
-                modifier = modifier.width(timesWidth),
+                modifier = modifier.width(timesWidth)
+                ,
             ) {
                 for (i in 1..timeTable[0].subjects.size) {
                     Text(
                         text = i.toString(),
                         modifier = modifier
+                            .fillMaxSize()
+                            .border(
+                                width = 1.dp,
+                                color = Color.LightGray,
+                            )
                             .wrapContentHeight()
                             .weight(.1f),
                     )
                 }
             }
-            Row() {
+            Row(
+                modifier = modifier.background(
+                    shape = RoundedCornerShape(4.dp),
+                    color = MaterialTheme.colorScheme.background
+                )
+            ) {
                 timeTable.forEach { daily ->
-                    DailyColumn(dailySubject = daily.subjects, modifier = modifier.weight(.1f))
+                    Box(modifier = modifier.weight(.1f)){
+                        BlankColumn()
+                        DailyColumn(dailySubject = daily.subjects)
+                    }
                 }
             }
         }
@@ -71,15 +98,31 @@ fun TimeTable(
 }
 
 @Composable
+fun BlankColumn(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        for(i in 1..5) {
+            BlackSubject(modifier = modifier.weight(.1f))
+        }
+    }
+}
+
+@Composable
 fun DailyColumn(
     modifier: Modifier = Modifier,
-    dailySubject: List<Subject>,
+    dailySubject: Map<Int, Subject?>,
 ) {
     Column(
         modifier = modifier,
     ) {
         dailySubject.forEach {
-            SubjectCard(subject = it, modifier = modifier.weight(.1f))
+            it.value.let {subject -> 
+                if (subject != null)SubjectCard(subject = subject, modifier = modifier.weight(.1f))
+                else Spacer(modifier = modifier.weight(.1f))
+            }
         }
     }
 }
@@ -103,4 +146,18 @@ fun SubjectCard(
             Text(text = subject.teacher ?: "")
         }
     }
+}
+
+@Composable
+fun BlackSubject(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .border(
+                width = 1.dp,
+                color = Color.LightGray,
+            )
+    )
 }

--- a/app/src/main/java/com/example/timetable/ui/main/MockTimeTable.kt
+++ b/app/src/main/java/com/example/timetable/ui/main/MockTimeTable.kt
@@ -7,52 +7,52 @@ object MockTimeTable {
     val timetable = listOf(
         DailyTables(
             week = "月",
-            subjects = listOf(
-                Subject(subjectName = "1", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "2", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "3", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "4", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "5", classRoom = null, teacher = null, subjectColor = ""),
+            subjects = mapOf(
+                1 to Subject(subjectName = "プロジェクト・マネージメント", classRoom = null, teacher = null, subjectColor = ""),
+                2 to Subject(subjectName = "解析", classRoom = null, teacher = null, subjectColor = ""),
+                3 to Subject(subjectName = "線形代数", classRoom = null, teacher = null, subjectColor = ""),
+                4 to Subject(subjectName = "プロジェクト学習", classRoom = null, teacher = null, subjectColor = ""),
+                5 to Subject(subjectName = "プロジェクト学習", classRoom = null, teacher = null, subjectColor = ""),
             ),
         ),
         DailyTables(
             week = "火",
-            subjects = listOf(
-                Subject(subjectName = "1", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "2", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "3", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "4", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "5", classRoom = null, teacher = null, subjectColor = ""),
+            subjects = mapOf(
+                1 to Subject(subjectName = "コンピューターと教育", classRoom = null, teacher = null, subjectColor = ""),
+                2 to null,
+                3 to Subject(subjectName = "余暇と健康I", classRoom = null, teacher = null, subjectColor = ""),
+                4 to null,
+                5 to null,
             ),
         ),
         DailyTables(
             week = "水",
-            subjects = listOf(
-                Subject(subjectName = "1", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "2", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "3", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "4", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "5", classRoom = null, teacher = null, subjectColor = ""),
+            subjects = mapOf(
+                1 to null,
+                2 to Subject(subjectName = "ITアーキテクチャ", classRoom = null, teacher = null, subjectColor = ""),
+                3 to null,
+                4 to Subject(subjectName = "プロジェクト学習", classRoom = null, teacher = null, subjectColor = ""),
+                5 to Subject(subjectName = "プロジェクト学習", classRoom = null, teacher = null, subjectColor = ""),
             ),
         ),
         DailyTables(
             week = "木",
-            subjects = listOf(
-                Subject(subjectName = "1", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "2", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "3", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "4", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "5", classRoom = null, teacher = null, subjectColor = ""),
+            subjects = mapOf(
+                1 to Subject(subjectName = "応用数学I", classRoom = null, teacher = null, subjectColor = ""),
+                2 to Subject(subjectName = "ICTデザイン通論", classRoom = null, teacher = null, subjectColor = ""),
+                3 to null,
+                4 to null,
+                5 to null,
             ),
         ),
         DailyTables(
             week = "金",
-            subjects = listOf(
-                Subject(subjectName = "1", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "2", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "3", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "4", classRoom = null, teacher = null, subjectColor = ""),
-                Subject(subjectName = "5", classRoom = null, teacher = null, subjectColor = ""),
+            subjects = mapOf(
+                1 to Subject(subjectName = "解析", classRoom = null, teacher = null, subjectColor = ""),
+                2 to null,
+                3 to Subject(subjectName = "課外研究", classRoom = null, teacher = null, subjectColor = ""),
+                4 to Subject(subjectName = "課外研究", classRoom = null, teacher = null, subjectColor = ""),
+                5 to null,
             ),
         ),
     )

--- a/app/src/main/java/com/example/timetable/ui/main/timeTable/BlankTable.kt
+++ b/app/src/main/java/com/example/timetable/ui/main/timeTable/BlankTable.kt
@@ -1,0 +1,116 @@
+package com.example.timetable.ui.main.timeTable
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.example.timetable.model.source.DailyTables
+
+@Composable
+fun BlankTable(
+    modifier: Modifier = Modifier,
+    timeTable: List<DailyTables>,
+) {
+    val timesWidth = 20.dp
+    Column() {
+        // Top Row Display Weeks
+        Row(
+            modifier = modifier.fillMaxWidth(),
+        ) {
+            val tableWeight = 1f
+            Spacer(modifier = modifier.width(timesWidth))
+            timeTable.forEach { daily ->
+                Text(
+                    text = daily.week,
+                    modifier = modifier
+                        .weight(tableWeight)
+                        .height(24.dp)
+                        .border(
+                            width = 1.dp,
+                            color = Color.LightGray,
+                        ),
+                    textAlign = TextAlign.Center
+                    ,
+                )
+            }
+        }
+
+        // Display TimeTable
+        Row(
+            modifier = modifier.fillMaxWidth(),
+        ) {
+            Column(
+                modifier = modifier.width(timesWidth)
+                ,
+            ) {
+                for (i in 1..timeTable[0].subjects.size) {
+                    Text(
+                        text = i.toString(),
+                        modifier = modifier
+                            .fillMaxSize()
+                            .border(
+                                width = 1.dp,
+                                color = Color.LightGray,
+                            )
+                            .wrapContentHeight()
+                            .weight(.1f),
+                    )
+                }
+            }
+            Row(
+                modifier = modifier.background(
+                    shape = RoundedCornerShape(4.dp),
+                    color = MaterialTheme.colorScheme.background
+                )
+            ) {
+                timeTable.forEach { daily ->
+                    Box(modifier = modifier.weight(.1f)){
+                        BlankColumn()
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun BlankColumn(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        for(i in 1..5) {
+            BlackSubject(modifier = modifier.weight(.1f))
+        }
+    }
+}
+
+@Composable
+fun BlackSubject(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .border(
+                width = 1.dp,
+                color = Color.LightGray,
+            )
+    )
+}

--- a/app/src/main/java/com/example/timetable/ui/main/timeTable/BlankTable.kt
+++ b/app/src/main/java/com/example/timetable/ui/main/timeTable/BlankTable.kt
@@ -14,9 +14,9 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.example.timetable.model.source.DailyTables
@@ -41,13 +41,16 @@ fun BlankTable(
             val tableWeight = 1f
             Spacer(modifier = modifier.width(timesWidth))
             timeTable.forEach { daily ->
-                Text(
-                    text = daily.week,
+                Box(
                     modifier = modifier
                         .weight(tableWeight)
                         .height(weeksHeight),
-                    textAlign = TextAlign.Center,
-                )
+                ) {
+                    Text(
+                        text = daily.week,
+                        modifier = modifier.align(Alignment.Center)
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/com/example/timetable/ui/main/timeTable/BlankTable.kt
+++ b/app/src/main/java/com/example/timetable/ui/main/timeTable/BlankTable.kt
@@ -1,7 +1,6 @@
 package com.example.timetable.ui.main.timeTable
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,15 +8,16 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.example.timetable.model.source.DailyTables
 
@@ -25,12 +25,18 @@ import com.example.timetable.model.source.DailyTables
 fun BlankTable(
     modifier: Modifier = Modifier,
     timeTable: List<DailyTables>,
+    weeksHeight: Dp,
+    timesWidth: Dp,
 ) {
-    val timesWidth = 20.dp
-    Column() {
+    Column(
+        modifier = modifier
+            .background(
+                color = Color.LightGray
+            ),
+    ) {
         // Top Row Display Weeks
         Row(
-            modifier = modifier.fillMaxWidth(),
+            modifier = modifier.fillMaxWidth()
         ) {
             val tableWeight = 1f
             Spacer(modifier = modifier.width(timesWidth))
@@ -39,13 +45,8 @@ fun BlankTable(
                     text = daily.week,
                     modifier = modifier
                         .weight(tableWeight)
-                        .height(24.dp)
-                        .border(
-                            width = 1.dp,
-                            color = Color.LightGray,
-                        ),
-                    textAlign = TextAlign.Center
-                    ,
+                        .height(weeksHeight),
+                    textAlign = TextAlign.Center,
                 )
             }
         }
@@ -63,20 +64,12 @@ fun BlankTable(
                         text = i.toString(),
                         modifier = modifier
                             .fillMaxSize()
-                            .border(
-                                width = 1.dp,
-                                color = Color.LightGray,
-                            )
                             .wrapContentHeight()
                             .weight(.1f),
                     )
                 }
             }
             Row(
-                modifier = modifier.background(
-                    shape = RoundedCornerShape(4.dp),
-                    color = MaterialTheme.colorScheme.background
-                )
             ) {
                 timeTable.forEach { daily ->
                     Box(modifier = modifier.weight(.1f)){
@@ -93,7 +86,6 @@ fun BlankColumn(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier,
     ) {
         for(i in 1..5) {
             BlackSubject(modifier = modifier.weight(.1f))
@@ -108,9 +100,10 @@ fun BlackSubject(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .border(
-                width = 1.dp,
-                color = Color.LightGray,
+            .padding(2.dp)
+            .background(
+                color = Color.White,
+                shape = RoundedCornerShape(4.dp)
             )
     )
 }

--- a/app/src/main/java/com/example/timetable/ui/main/timeTable/BlankTable.kt
+++ b/app/src/main/java/com/example/timetable/ui/main/timeTable/BlankTable.kt
@@ -32,7 +32,8 @@ fun BlankTable(
         modifier = modifier
             .background(
                 color = Color.LightGray,
-            ),
+            )
+            .padding(4.dp),
     ) {
         // Top Row Display Weeks
         Row(

--- a/app/src/main/java/com/example/timetable/ui/main/timeTable/BlankTable.kt
+++ b/app/src/main/java/com/example/timetable/ui/main/timeTable/BlankTable.kt
@@ -31,12 +31,12 @@ fun BlankTable(
     Column(
         modifier = modifier
             .background(
-                color = Color.LightGray
+                color = Color.LightGray,
             ),
     ) {
         // Top Row Display Weeks
         Row(
-            modifier = modifier.fillMaxWidth()
+            modifier = modifier.fillMaxWidth(),
         ) {
             val tableWeight = 1f
             Spacer(modifier = modifier.width(timesWidth))
@@ -48,7 +48,7 @@ fun BlankTable(
                 ) {
                     Text(
                         text = daily.week,
-                        modifier = modifier.align(Alignment.Center)
+                        modifier = modifier.align(Alignment.Center),
                     )
                 }
             }
@@ -59,8 +59,7 @@ fun BlankTable(
             modifier = modifier.fillMaxWidth(),
         ) {
             Column(
-                modifier = modifier.width(timesWidth)
-                ,
+                modifier = modifier.width(timesWidth),
             ) {
                 for (i in 1..timeTable[0].subjects.size) {
                     Text(
@@ -72,10 +71,9 @@ fun BlankTable(
                     )
                 }
             }
-            Row(
-            ) {
+            Row() {
                 timeTable.forEach { daily ->
-                    Box(modifier = modifier.weight(.1f)){
+                    Box(modifier = modifier.weight(.1f)) {
                         BlankColumn()
                     }
                 }
@@ -88,9 +86,8 @@ fun BlankTable(
 fun BlankColumn(
     modifier: Modifier = Modifier,
 ) {
-    Column(
-    ) {
-        for(i in 1..5) {
+    Column() {
+        for (i in 1..5) {
             BlackSubject(modifier = modifier.weight(.1f))
         }
     }
@@ -106,7 +103,7 @@ fun BlackSubject(
             .padding(2.dp)
             .background(
                 color = Color.White,
-                shape = RoundedCornerShape(4.dp)
-            )
+                shape = RoundedCornerShape(4.dp),
+            ),
     )
 }

--- a/app/src/main/java/com/example/timetable/ui/main/timeTable/TimeTable.kt
+++ b/app/src/main/java/com/example/timetable/ui/main/timeTable/TimeTable.kt
@@ -93,7 +93,7 @@ fun SubjectCard(
             modifier = modifier
                 .fillMaxSize()
                 .padding(4.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
                 text = subject.subjectName,

--- a/app/src/main/java/com/example/timetable/ui/main/timeTable/TimeTable.kt
+++ b/app/src/main/java/com/example/timetable/ui/main/timeTable/TimeTable.kt
@@ -1,0 +1,90 @@
+package com.example.timetable.ui.main.timeTable
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.example.timetable.model.source.DailyTables
+import com.example.timetable.model.source.Subject
+
+@Composable
+fun TimeTable(
+    modifier: Modifier = Modifier,
+    timeTable: List<DailyTables>,
+) {
+    val timesWidth = 20.dp
+    Column() {
+        Spacer(
+            modifier = modifier
+                .fillMaxWidth().height(24.dp)
+        )
+
+        // Display TimeTable
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+        ) {
+            Spacer(modifier = modifier.width(timesWidth))
+            Row(
+                modifier = modifier.background(
+                    color = Color.Transparent,
+                )
+            ) {
+                timeTable.forEach { daily ->
+                    Box(modifier = modifier.weight(.1f)){
+                        DailyColumn(dailySubject = daily.subjects)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun DailyColumn(
+    modifier: Modifier = Modifier,
+    dailySubject: Map<Int, Subject?>,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        dailySubject.forEach {
+            it.value.let {subject ->
+                if (subject != null)SubjectCard(subject = subject, modifier = modifier.weight(.1f))
+                else Spacer(modifier = modifier.weight(.1f))
+            }
+        }
+    }
+}
+
+@Composable
+fun SubjectCard(
+    modifier: Modifier = Modifier,
+    subject: Subject,
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(4.dp),
+    ) {
+        Column(
+            modifier = modifier
+                .padding(4.dp),
+        ) {
+            Text(text = subject.subjectName)
+            Text(text = subject.classRoom ?: "")
+            Text(text = subject.teacher ?: "")
+        }
+    }
+}

--- a/app/src/main/java/com/example/timetable/ui/main/timeTable/TimeTable.kt
+++ b/app/src/main/java/com/example/timetable/ui/main/timeTable/TimeTable.kt
@@ -5,16 +5,20 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.example.timetable.model.source.DailyTables
@@ -30,22 +34,22 @@ fun TimeTable(
     Column() {
         Spacer(
             modifier = modifier
-                .fillMaxWidth().height(weeksHeight)
+                .fillMaxWidth().height(weeksHeight),
         )
 
         // Display TimeTable
         Row(
             modifier = modifier
-                .fillMaxWidth()
+                .fillMaxWidth(),
         ) {
             Spacer(modifier = modifier.width(timesWidth))
             Row(
                 modifier = modifier.background(
                     color = Color.Transparent,
-                )
+                ),
             ) {
                 timeTable.forEach { daily ->
-                    Box(modifier = modifier.weight(.1f)){
+                    Box(modifier = modifier.weight(.1f)) {
                         DailyColumn(dailySubject = daily.subjects)
                     }
                 }
@@ -63,9 +67,12 @@ fun DailyColumn(
         modifier = modifier,
     ) {
         dailySubject.forEach {
-            it.value.let {subject ->
-                if (subject != null)SubjectCard(subject = subject, modifier = modifier.weight(.1f))
-                else Spacer(modifier = modifier.weight(.1f))
+            it.value.let { subject ->
+                if (subject != null) {
+                    SubjectCard(subject = subject, modifier = modifier.weight(.1f))
+                } else {
+                    Spacer(modifier = modifier.weight(.1f))
+                }
             }
         }
     }
@@ -80,15 +87,29 @@ fun SubjectCard(
         modifier = modifier
             .fillMaxWidth()
             .padding(2.dp),
-        shape = RoundedCornerShape(4.dp)
+        shape = RoundedCornerShape(4.dp),
     ) {
         Column(
             modifier = modifier
+                .fillMaxSize()
                 .padding(4.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Text(text = subject.subjectName)
-            Text(text = subject.classRoom ?: "")
-            Text(text = subject.teacher ?: "")
+            Text(
+                text = subject.subjectName,
+                style = MaterialTheme.typography.bodySmall,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = subject.classRoom ?: "",
+                style = MaterialTheme.typography.bodySmall,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = subject.teacher ?: "",
+                style = MaterialTheme.typography.bodySmall,
+                textAlign = TextAlign.Center,
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/timetable/ui/main/timeTable/TimeTable.kt
+++ b/app/src/main/java/com/example/timetable/ui/main/timeTable/TimeTable.kt
@@ -9,11 +9,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.example.timetable.model.source.DailyTables
 import com.example.timetable.model.source.Subject
@@ -22,12 +24,13 @@ import com.example.timetable.model.source.Subject
 fun TimeTable(
     modifier: Modifier = Modifier,
     timeTable: List<DailyTables>,
+    weeksHeight: Dp,
+    timesWidth: Dp,
 ) {
-    val timesWidth = 20.dp
     Column() {
         Spacer(
             modifier = modifier
-                .fillMaxWidth().height(24.dp)
+                .fillMaxWidth().height(weeksHeight)
         )
 
         // Display TimeTable
@@ -76,7 +79,8 @@ fun SubjectCard(
     Card(
         modifier = modifier
             .fillMaxWidth()
-            .padding(4.dp),
+            .padding(2.dp),
+        shape = RoundedCornerShape(4.dp)
     ) {
         Column(
             modifier = modifier

--- a/app/src/main/java/com/example/timetable/ui/main/timeTable/TimeTable.kt
+++ b/app/src/main/java/com/example/timetable/ui/main/timeTable/TimeTable.kt
@@ -31,7 +31,9 @@ fun TimeTable(
     weeksHeight: Dp,
     timesWidth: Dp,
 ) {
-    Column() {
+    Column(
+        modifier = modifier.padding(4.dp),
+    ) {
         Spacer(
             modifier = modifier
                 .fillMaxWidth().height(weeksHeight),


### PR DESCRIPTION
## マージの目的
空のテーブルの表示ができるようにする（グリッド線のようなものが表示されればOK）

## 対応するIssue
- Closes #9 

## 変更内容
- MainScreenにからのテーブルの表示を作る

## 確認内容
- 

## 参考画像
<img width =300 src="https://user-images.githubusercontent.com/60728861/221186954-6534d375-c063-41c2-a11f-194f80396d17.png">

