### PR TITLE
[Feat]ボトムナビゲーションを用いた，科目管理画面へ遷移

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -100,6 +100,7 @@ dependencies {
 
     //Navigation
     implementation("androidx.navigation:navigation-compose:2.5.3")
+    implementation("androidx.compose.material:material:1.3.1")
 
     //hilt
     implementation 'com.google.dagger:hilt-android:2.45'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -102,6 +102,9 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:2.5.3")
     implementation("androidx.compose.material:material:1.3.1")
 
+    //icon
+    implementation("androidx.compose.material:material-icons-extended:1.3.1")
+
     //hilt
     implementation 'com.google.dagger:hilt-android:2.45'
     kapt 'com.google.dagger:hilt-compiler:2.45'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,6 +98,9 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.6.0-beta01"
     implementation "androidx.lifecycle:lifecycle-runtime-compose:2.6.0-beta01"
 
+    //Navigation
+    implementation("androidx.navigation:navigation-compose:2.5.3")
+
     //hilt
     implementation 'com.google.dagger:hilt-android:2.45'
     kapt 'com.google.dagger:hilt-compiler:2.45'

--- a/app/src/main/java/com/example/timetable/AppNavHost.kt
+++ b/app/src/main/java/com/example/timetable/AppNavHost.kt
@@ -1,10 +1,21 @@
 package com.example.timetable
 
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.BottomNavigation
+import androidx.compose.material.BottomNavigationItem
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavDestination.Companion.hierarchy
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.example.timetable.ui.addSubject.AddSubjectScreen
 import com.example.timetable.ui.table.TableScreen
@@ -15,8 +26,40 @@ fun AppNavHost(
     startDestination: String,
 ) {
     val navController = rememberNavController()
-    Column() {
+    Scaffold(
+        bottomBar = {
+            BottomNavigation(
+                backgroundColor = MaterialTheme.colors.background
+            ) {
+                val navBackStackEntry by navController.currentBackStackEntryAsState()
+                val currentDestination = navBackStackEntry?.destination
+
+                TopLevelDestinations.values().forEach { item ->
+                    BottomNavigationItem(
+                        selected = currentDestination?.hierarchy?.any { it.route == item.destinations.route } == true,
+                        icon = {Icon(item.destinations.icon, null)},
+                        label = {
+                            Text(
+                                text = stringResource(id = item.destinations.title),
+                                maxLines = 1
+                            )
+                        },
+                        onClick = {
+                            navController.navigate(item.destinations.route){
+                                popUpTo(navController.graph.findStartDestination().id){
+                                    saveState = true
+                                }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    ) { innerPadding ->
         NavHost(
+            modifier = Modifier.padding(innerPadding),
             navController = navController,
             startDestination = startDestination,
         ) {
@@ -27,7 +70,5 @@ fun AppNavHost(
                 AddSubjectScreen()
             }
         }
-
-
     }
 }

--- a/app/src/main/java/com/example/timetable/AppNavHost.kt
+++ b/app/src/main/java/com/example/timetable/AppNavHost.kt
@@ -1,0 +1,29 @@
+package com.example.timetable
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.timetable.ui.addSubject.AddSubjectScreen
+import com.example.timetable.ui.main.MainScreen
+
+@Composable
+fun AppNavHost(
+    modifier: Modifier = Modifier,
+    startDestination: String,
+) {
+    val navController = rememberNavController()
+
+    NavHost(
+        navController = navController,
+        startDestination = startDestination
+    ){
+        composable(route = Destinations.TimeTableScreen.route){
+            MainScreen()
+        }
+        composable(route = Destinations.SubjectsScreen.route){
+            AddSubjectScreen()
+        }
+    }
+}

--- a/app/src/main/java/com/example/timetable/AppNavHost.kt
+++ b/app/src/main/java/com/example/timetable/AppNavHost.kt
@@ -17,12 +17,12 @@ fun AppNavHost(
 
     NavHost(
         navController = navController,
-        startDestination = startDestination
-    ){
-        composable(route = Destinations.TimeTableScreen.route){
+        startDestination = startDestination,
+    ) {
+        composable(route = Destinations.TimeTableScreen.route) {
             MainScreen()
         }
-        composable(route = Destinations.SubjectsScreen.route){
+        composable(route = Destinations.SubjectsScreen.route) {
             AddSubjectScreen()
         }
     }

--- a/app/src/main/java/com/example/timetable/AppNavHost.kt
+++ b/app/src/main/java/com/example/timetable/AppNavHost.kt
@@ -1,12 +1,13 @@
 package com.example.timetable
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.example.timetable.ui.addSubject.AddSubjectScreen
-import com.example.timetable.ui.main.MainScreen
+import com.example.timetable.ui.table.TableScreen
 
 @Composable
 fun AppNavHost(
@@ -14,16 +15,19 @@ fun AppNavHost(
     startDestination: String,
 ) {
     val navController = rememberNavController()
+    Column() {
+        NavHost(
+            navController = navController,
+            startDestination = startDestination,
+        ) {
+            composable(route = Destinations.TableScreen.route) {
+                TableScreen()
+            }
+            composable(route = Destinations.SubjectsScreen.route) {
+                AddSubjectScreen()
+            }
+        }
 
-    NavHost(
-        navController = navController,
-        startDestination = startDestination,
-    ) {
-        composable(route = Destinations.TimeTableScreen.route) {
-            MainScreen()
-        }
-        composable(route = Destinations.SubjectsScreen.route) {
-            AddSubjectScreen()
-        }
+
     }
 }

--- a/app/src/main/java/com/example/timetable/AppNavHost.kt
+++ b/app/src/main/java/com/example/timetable/AppNavHost.kt
@@ -29,7 +29,7 @@ fun AppNavHost(
     Scaffold(
         bottomBar = {
             BottomNavigation(
-                backgroundColor = MaterialTheme.colors.background
+                backgroundColor = MaterialTheme.colors.background,
             ) {
                 val navBackStackEntry by navController.currentBackStackEntryAsState()
                 val currentDestination = navBackStackEntry?.destination
@@ -37,26 +37,26 @@ fun AppNavHost(
                 TopLevelDestinations.values().forEach { item ->
                     BottomNavigationItem(
                         selected = currentDestination?.hierarchy?.any { it.route == item.destinations.route } == true,
-                        icon = {Icon(item.destinations.icon, null)},
+                        icon = { Icon(item.destinations.icon, null) },
                         label = {
                             Text(
                                 text = stringResource(id = item.destinations.title),
-                                maxLines = 1
+                                maxLines = 1,
                             )
                         },
                         onClick = {
-                            navController.navigate(item.destinations.route){
-                                popUpTo(navController.graph.findStartDestination().id){
+                            navController.navigate(item.destinations.route) {
+                                popUpTo(navController.graph.findStartDestination().id) {
                                     saveState = true
                                 }
                                 launchSingleTop = true
                                 restoreState = true
                             }
-                        }
+                        },
                     )
                 }
             }
-        }
+        },
     ) { innerPadding ->
         NavHost(
             modifier = Modifier.padding(innerPadding),

--- a/app/src/main/java/com/example/timetable/Destinations.kt
+++ b/app/src/main/java/com/example/timetable/Destinations.kt
@@ -1,0 +1,18 @@
+package com.example.timetable
+
+sealed class Destinations(
+    val route: String,
+    val title: String,
+) {
+
+    object TimeTableScreen: Destinations(
+        route = "timetable_screen",
+        title = "時間割り",
+    )
+
+    object SubjectsScreen: Destinations(
+        route = "subjects_screen",
+        title = "科目管理",
+    )
+
+}

--- a/app/src/main/java/com/example/timetable/Destinations.kt
+++ b/app/src/main/java/com/example/timetable/Destinations.kt
@@ -5,14 +5,13 @@ sealed class Destinations(
     val title: String,
 ) {
 
-    object TimeTableScreen: Destinations(
+    object TimeTableScreen : Destinations(
         route = "timetable_screen",
         title = "時間割り",
     )
 
-    object SubjectsScreen: Destinations(
+    object SubjectsScreen : Destinations(
         route = "subjects_screen",
         title = "科目管理",
     )
-
 }

--- a/app/src/main/java/com/example/timetable/Destinations.kt
+++ b/app/src/main/java/com/example/timetable/Destinations.kt
@@ -1,19 +1,26 @@
 package com.example.timetable
 
 import androidx.annotation.StringRes
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.List
+import androidx.compose.material.icons.outlined.TableView
+import androidx.compose.ui.graphics.vector.ImageVector
 
 sealed class Destinations(
     @StringRes val title: Int,
+    val icon: ImageVector,
     val route: String,
 ) {
 
     object TableScreen : Destinations(
         title = R.string.timetable_title,
+        icon = Icons.Outlined.TableView,
         route = "table_screen",
     )
 
     object SubjectsScreen : Destinations(
         title = R.string.subjects_title,
+        icon = Icons.Outlined.List,
         route = "subjects_screen",
     )
 }

--- a/app/src/main/java/com/example/timetable/Destinations.kt
+++ b/app/src/main/java/com/example/timetable/Destinations.kt
@@ -1,18 +1,20 @@
 package com.example.timetable
 
+import androidx.annotation.StringRes
+
 sealed class Destinations(
+    @StringRes val title: Int,
     val route: String,
-    val title: String,
 ) {
 
     object TableScreen : Destinations(
+        title = R.string.timetable_title,
         route = "table_screen",
-        title = "時間割り",
     )
 
     object SubjectsScreen : Destinations(
+        title = R.string.subjects_title,
         route = "subjects_screen",
-        title = "科目管理",
     )
 }
 

--- a/app/src/main/java/com/example/timetable/Destinations.kt
+++ b/app/src/main/java/com/example/timetable/Destinations.kt
@@ -5,8 +5,8 @@ sealed class Destinations(
     val title: String,
 ) {
 
-    object TimeTableScreen : Destinations(
-        route = "timetable_screen",
+    object TableScreen : Destinations(
+        route = "table_screen",
         title = "時間割り",
     )
 
@@ -14,4 +14,11 @@ sealed class Destinations(
         route = "subjects_screen",
         title = "科目管理",
     )
+}
+
+enum class TopLevelDestinations(
+    val destinations: Destinations
+){
+    TABLE(Destinations.TableScreen),
+    SUBJECT(Destinations.SubjectsScreen),
 }

--- a/app/src/main/java/com/example/timetable/Destinations.kt
+++ b/app/src/main/java/com/example/timetable/Destinations.kt
@@ -26,8 +26,8 @@ sealed class Destinations(
 }
 
 enum class TopLevelDestinations(
-    val destinations: Destinations
-){
+    val destinations: Destinations,
+) {
     TABLE(Destinations.TableScreen),
     SUBJECT(Destinations.SubjectsScreen),
 }

--- a/app/src/main/java/com/example/timetable/MainActivity.kt
+++ b/app/src/main/java/com/example/timetable/MainActivity.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
-import com.example.timetable.ui.main.MainScreen
 import com.example.timetable.ui.theme.TimeTableTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -22,7 +21,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background,
                 ) {
-                    MainScreen()
+                    AppNavHost(startDestination = Destinations.TableScreen.route)
                 }
             }
         }

--- a/app/src/main/java/com/example/timetable/ui/table/MockTimeTable.kt
+++ b/app/src/main/java/com/example/timetable/ui/table/MockTimeTable.kt
@@ -1,4 +1,4 @@
-package com.example.timetable.ui.main
+package com.example.timetable.ui.table
 
 import com.example.timetable.model.source.DailyTables
 import com.example.timetable.model.source.Subject

--- a/app/src/main/java/com/example/timetable/ui/table/TableScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/table/TableScreen.kt
@@ -1,14 +1,14 @@
-package com.example.timetable.ui.main
+package com.example.timetable.ui.table
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.example.timetable.ui.main.timeTable.BlankTable
-import com.example.timetable.ui.main.timeTable.TimeTable
+import com.example.timetable.ui.table.timeTable.BlankTable
+import com.example.timetable.ui.table.timeTable.TimeTable
 
 @Composable
-fun MainScreen(
+fun TableScreen(
     modifier: Modifier = Modifier,
 ) {
     val weeksHeight = 32.dp

--- a/app/src/main/java/com/example/timetable/ui/table/timeTable/BlankTable.kt
+++ b/app/src/main/java/com/example/timetable/ui/table/timeTable/BlankTable.kt
@@ -1,4 +1,4 @@
-package com.example.timetable.ui.main.timeTable
+package com.example.timetable.ui.table.timeTable
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box

--- a/app/src/main/java/com/example/timetable/ui/table/timeTable/TimeTable.kt
+++ b/app/src/main/java/com/example/timetable/ui/table/timeTable/TimeTable.kt
@@ -1,4 +1,4 @@
-package com.example.timetable.ui.main.timeTable
+package com.example.timetable.ui.table.timeTable
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,7 @@
     <string name="subject_name">科目名</string>
     <string name="class_room">教室</string>
     <string name="teacher">教師</string>
+
+    <string name="timetable_title">時間割り</string>
+    <string name="subjects_title">科目管理</string>
 </resources>


### PR DESCRIPTION
## マージの目的
ボトムナビゲーションを使用可能にすること
科目の管理画面に遷移をするため
#12 
## 変更内容
- ボトムナビゲーションの実装
- ボトムナビゲーションから科目管理画面と時間割画面を行き来できるように

## 確認内容
- fuga

## 参考画像
- <img width=300 src="https://user-images.githubusercontent.com/60728861/222691893-892ed536-45e1-4311-bd2e-5b2ea50ef8f1.png"/>

