### PR TITLE
[Feat]科目追加画面を科目管理画面と分離

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -102,6 +102,9 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:2.5.3")
     implementation("androidx.compose.material:material:1.3.1")
 
+    implementation "com.google.accompanist:accompanist-navigation-animation:0.16.1"
+
+
     //icon
     implementation("androidx.compose.material:material-icons-extended:1.3.1")
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -102,7 +102,7 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:2.5.3")
     implementation("androidx.compose.material:material:1.3.1")
 
-    implementation "com.google.accompanist:accompanist-navigation-animation:0.16.1"
+    implementation "com.google.accompanist:accompanist-navigation-animation:0.29.1-alpha"
 
 
     //icon

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -102,7 +102,7 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:2.5.3")
     implementation("androidx.compose.material:material:1.3.1")
 
-    implementation "com.google.accompanist:accompanist-navigation-animation:0.29.1-alpha"
+    implementation "com.google.accompanist:accompanist-navigation-animation:0.28.0"
 
 
     //icon

--- a/app/src/main/java/com/example/timetable/AppNavHost.kt
+++ b/app/src/main/java/com/example/timetable/AppNavHost.kt
@@ -17,7 +17,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import com.example.timetable.ui.addSubject.AddSubjectScreen
+import com.example.timetable.ui.manageSubjects.ManageSubjectsScreen
 import com.example.timetable.ui.table.TableScreen
 
 @Composable
@@ -66,8 +66,8 @@ fun AppNavHost(
             composable(route = Destinations.TableScreen.route) {
                 TableScreen()
             }
-            composable(route = Destinations.SubjectsScreen.route) {
-                AddSubjectScreen()
+            composable(route = Destinations.ManageSubjectsScreen.route) {
+                ManageSubjectsScreen()
             }
         }
     }

--- a/app/src/main/java/com/example/timetable/AppNavHost.kt
+++ b/app/src/main/java/com/example/timetable/AppNavHost.kt
@@ -12,8 +12,6 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavDestination.Companion.hierarchy
@@ -25,7 +23,6 @@ import com.example.timetable.ui.table.TableScreen
 import com.google.accompanist.navigation.animation.AnimatedNavHost
 import com.google.accompanist.navigation.animation.composable
 import com.google.accompanist.navigation.animation.rememberAnimatedNavController
-
 
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
@@ -39,14 +36,12 @@ fun AppNavHost(
     val bottomBarState = showedScreen != Destinations.AddSubjectScreen.route
     Scaffold(
         bottomBar = {
-            if(bottomBarState) {
+            if (bottomBarState) {
                 BottomNavigation(
                     backgroundColor = MaterialTheme.colors.background,
                 ) {
                     val navBackStackEntry by navController.currentBackStackEntryAsState()
                     val currentDestination = navBackStackEntry?.destination
-
-                    val bottomBarState by rememberSaveable { mutableStateOf(true) }
 
                     TopLevelDestinations.values().forEach { item ->
                         BottomNavigationItem(
@@ -83,20 +78,20 @@ fun AppNavHost(
             }
             composable(route = Destinations.ManageSubjectsScreen.route) {
                 ManageSubjectsScreen(
-                    transitionToAddSubject = {navController.navigate(Destinations.AddSubjectScreen.route)}
+                    transitionToAddSubject = { navController.navigate(Destinations.AddSubjectScreen.route) },
                 )
             }
             composable(
                 route = Destinations.AddSubjectScreen.route,
                 enterTransition = {
-                    slideInVertically(initialOffsetY = {fullHeight ->  fullHeight})
+                    slideInVertically(initialOffsetY = { fullHeight -> fullHeight })
                 },
                 exitTransition = {
-                    slideOutVertically(targetOffsetY = {fullHeight -> fullHeight })
-                }
-            ){
+                    slideOutVertically(targetOffsetY = { fullHeight -> fullHeight })
+                },
+            ) {
                 AddSubjectScreen(
-                    transitionToBackStack = { navController.popBackStack() }
+                    transitionToBackStack = { navController.popBackStack() },
                 )
             }
         }

--- a/app/src/main/java/com/example/timetable/AppNavHost.kt
+++ b/app/src/main/java/com/example/timetable/AppNavHost.kt
@@ -84,10 +84,10 @@ fun AppNavHost(
             composable(
                 route = Destinations.AddSubjectScreen.route,
                 enterTransition = {
-                    slideInVertically(initialOffsetY = { fullHeight -> fullHeight-100 })
+                    slideInVertically(initialOffsetY = { fullHeight -> fullHeight - 100 })
                 },
                 exitTransition = {
-                    slideOutVertically(targetOffsetY = { fullHeight -> fullHeight-100 })
+                    slideOutVertically(targetOffsetY = { fullHeight -> fullHeight - 100 })
                 },
             ) {
                 AddSubjectScreen(

--- a/app/src/main/java/com/example/timetable/AppNavHost.kt
+++ b/app/src/main/java/com/example/timetable/AppNavHost.kt
@@ -2,6 +2,7 @@ package com.example.timetable
 
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationItem
@@ -89,6 +90,9 @@ fun AppNavHost(
                 route = Destinations.AddSubjectScreen.route,
                 enterTransition = {
                     slideInVertically(initialOffsetY = {fullHeight ->  fullHeight})
+                },
+                exitTransition = {
+                    slideOutVertically(targetOffsetY = {fullHeight -> fullHeight })
                 }
             ){
                 AddSubjectScreen()

--- a/app/src/main/java/com/example/timetable/AppNavHost.kt
+++ b/app/src/main/java/com/example/timetable/AppNavHost.kt
@@ -84,10 +84,10 @@ fun AppNavHost(
             composable(
                 route = Destinations.AddSubjectScreen.route,
                 enterTransition = {
-                    slideInVertically(initialOffsetY = { fullHeight -> fullHeight })
+                    slideInVertically(initialOffsetY = { fullHeight -> fullHeight-100 })
                 },
                 exitTransition = {
-                    slideOutVertically(targetOffsetY = { fullHeight -> fullHeight })
+                    slideOutVertically(targetOffsetY = { fullHeight -> fullHeight-100 })
                 },
             ) {
                 AddSubjectScreen(

--- a/app/src/main/java/com/example/timetable/AppNavHost.kt
+++ b/app/src/main/java/com/example/timetable/AppNavHost.kt
@@ -95,7 +95,9 @@ fun AppNavHost(
                     slideOutVertically(targetOffsetY = {fullHeight -> fullHeight })
                 }
             ){
-                AddSubjectScreen()
+                AddSubjectScreen(
+                    transitionToBackStack = { navController.popBackStack() }
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/timetable/AppNavHost.kt
+++ b/app/src/main/java/com/example/timetable/AppNavHost.kt
@@ -9,6 +9,8 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavDestination.Companion.hierarchy
@@ -17,6 +19,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.example.timetable.ui.addSubject.AddSubjectScreen
 import com.example.timetable.ui.manageSubjects.ManageSubjectsScreen
 import com.example.timetable.ui.table.TableScreen
 
@@ -26,34 +29,41 @@ fun AppNavHost(
     startDestination: String,
 ) {
     val navController = rememberNavController()
+
+    val showedScreen = navController.currentBackStackEntryAsState().value?.destination?.route
+    val bottomBarState = showedScreen != Destinations.AddSubjectScreen.route
     Scaffold(
         bottomBar = {
-            BottomNavigation(
-                backgroundColor = MaterialTheme.colors.background,
-            ) {
-                val navBackStackEntry by navController.currentBackStackEntryAsState()
-                val currentDestination = navBackStackEntry?.destination
+            if(bottomBarState) {
+                BottomNavigation(
+                    backgroundColor = MaterialTheme.colors.background,
+                ) {
+                    val navBackStackEntry by navController.currentBackStackEntryAsState()
+                    val currentDestination = navBackStackEntry?.destination
 
-                TopLevelDestinations.values().forEach { item ->
-                    BottomNavigationItem(
-                        selected = currentDestination?.hierarchy?.any { it.route == item.destinations.route } == true,
-                        icon = { Icon(item.destinations.icon, null) },
-                        label = {
-                            Text(
-                                text = stringResource(id = item.destinations.title),
-                                maxLines = 1,
-                            )
-                        },
-                        onClick = {
-                            navController.navigate(item.destinations.route) {
-                                popUpTo(navController.graph.findStartDestination().id) {
-                                    saveState = true
+                    val bottomBarState by rememberSaveable { mutableStateOf(true) }
+
+                    TopLevelDestinations.values().forEach { item ->
+                        BottomNavigationItem(
+                            selected = currentDestination?.hierarchy?.any { it.route == item.destinations.route } == true,
+                            icon = { Icon(item.destinations.icon, null) },
+                            label = {
+                                Text(
+                                    text = stringResource(id = item.destinations.title),
+                                    maxLines = 1,
+                                )
+                            },
+                            onClick = {
+                                navController.navigate(item.destinations.route) {
+                                    popUpTo(navController.graph.findStartDestination().id) {
+                                        saveState = true
+                                    }
+                                    launchSingleTop = true
+                                    restoreState = true
                                 }
-                                launchSingleTop = true
-                                restoreState = true
-                            }
-                        },
-                    )
+                            },
+                        )
+                    }
                 }
             }
         },
@@ -67,7 +77,12 @@ fun AppNavHost(
                 TableScreen()
             }
             composable(route = Destinations.ManageSubjectsScreen.route) {
-                ManageSubjectsScreen()
+                ManageSubjectsScreen(
+                    transitionToAddSubject = {navController.navigate(Destinations.AddSubjectScreen.route)}
+                )
+            }
+            composable(route = Destinations.AddSubjectScreen.route){
+                AddSubjectScreen()
             }
         }
     }

--- a/app/src/main/java/com/example/timetable/AppNavHost.kt
+++ b/app/src/main/java/com/example/timetable/AppNavHost.kt
@@ -1,5 +1,7 @@
 package com.example.timetable
 
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationItem
@@ -15,20 +17,22 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.rememberNavController
 import com.example.timetable.ui.addSubject.AddSubjectScreen
 import com.example.timetable.ui.manageSubjects.ManageSubjectsScreen
 import com.example.timetable.ui.table.TableScreen
+import com.google.accompanist.navigation.animation.AnimatedNavHost
+import com.google.accompanist.navigation.animation.composable
+import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 
+
+@OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun AppNavHost(
     modifier: Modifier = Modifier,
     startDestination: String,
 ) {
-    val navController = rememberNavController()
+    val navController = rememberAnimatedNavController()
 
     val showedScreen = navController.currentBackStackEntryAsState().value?.destination?.route
     val bottomBarState = showedScreen != Destinations.AddSubjectScreen.route
@@ -68,7 +72,7 @@ fun AppNavHost(
             }
         },
     ) { innerPadding ->
-        NavHost(
+        AnimatedNavHost(
             modifier = Modifier.padding(innerPadding),
             navController = navController,
             startDestination = startDestination,
@@ -81,7 +85,12 @@ fun AppNavHost(
                     transitionToAddSubject = {navController.navigate(Destinations.AddSubjectScreen.route)}
                 )
             }
-            composable(route = Destinations.AddSubjectScreen.route){
+            composable(
+                route = Destinations.AddSubjectScreen.route,
+                enterTransition = {
+                    slideInVertically(initialOffsetY = {fullHeight ->  fullHeight})
+                }
+            ){
                 AddSubjectScreen()
             }
         }

--- a/app/src/main/java/com/example/timetable/Destinations.kt
+++ b/app/src/main/java/com/example/timetable/Destinations.kt
@@ -2,6 +2,7 @@ package com.example.timetable
 
 import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.outlined.List
 import androidx.compose.material.icons.outlined.TableView
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -22,6 +23,12 @@ sealed class Destinations(
         title = R.string.subjects_title,
         icon = Icons.Outlined.List,
         route = "manage_subjects_screen",
+    )
+
+    object AddSubjectScreen: Destinations(
+        title = R.string.add_subjects_title,
+        icon = Icons.Default.Add,
+        route = "add_subject_screen"
     )
 
 }

--- a/app/src/main/java/com/example/timetable/Destinations.kt
+++ b/app/src/main/java/com/example/timetable/Destinations.kt
@@ -18,16 +18,17 @@ sealed class Destinations(
         route = "table_screen",
     )
 
-    object SubjectsScreen : Destinations(
+    object ManageSubjectsScreen : Destinations(
         title = R.string.subjects_title,
         icon = Icons.Outlined.List,
-        route = "subjects_screen",
+        route = "manage_subjects_screen",
     )
+
 }
 
 enum class TopLevelDestinations(
     val destinations: Destinations,
 ) {
     TABLE(Destinations.TableScreen),
-    SUBJECT(Destinations.SubjectsScreen),
+    SUBJECT(Destinations.ManageSubjectsScreen),
 }

--- a/app/src/main/java/com/example/timetable/Destinations.kt
+++ b/app/src/main/java/com/example/timetable/Destinations.kt
@@ -28,7 +28,7 @@ sealed class Destinations(
     object AddSubjectScreen: Destinations(
         title = R.string.add_subjects_title,
         icon = Icons.Default.Add,
-        route = "add_subject_screen"
+        route = "add_subject_screen",
     )
 
 }

--- a/app/src/main/java/com/example/timetable/Destinations.kt
+++ b/app/src/main/java/com/example/timetable/Destinations.kt
@@ -25,12 +25,11 @@ sealed class Destinations(
         route = "manage_subjects_screen",
     )
 
-    object AddSubjectScreen: Destinations(
+    object AddSubjectScreen : Destinations(
         title = R.string.add_subjects_title,
         icon = Icons.Default.Add,
         route = "add_subject_screen",
     )
-
 }
 
 enum class TopLevelDestinations(

--- a/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
@@ -7,12 +7,14 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -25,17 +27,15 @@ fun AddSubjectScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    Column() {
-        AddSubjectContent(
-            subjectName = uiState.subjectName,
-            classRoom = uiState.classRoom,
-            teacher = uiState.teacher,
-            updateSubjectName = viewModel::updateSubjectName,
-            updateClassRoom = viewModel::updateClassRoom,
-            updateTeacher = viewModel::updateTeacher,
-            registerSubject = viewModel::addSubject,
-        )
-    }
+    AddSubjectContent(
+        subjectName = uiState.subjectName,
+        classRoom = uiState.classRoom,
+        teacher = uiState.teacher,
+        updateSubjectName = viewModel::updateSubjectName,
+        updateClassRoom = viewModel::updateClassRoom,
+        updateTeacher = viewModel::updateTeacher,
+        registerSubject = viewModel::addSubject,
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -98,5 +98,21 @@ fun AddSubjectContent(
         ) {
             Text(text = "科目登録")
         }
+    }
+}
+
+@Preview
+@Composable
+fun PreviewAddSubject() {
+    Surface() {
+        AddSubjectContent(
+            subjectName = "",
+            classRoom = "",
+            teacher = "",
+            updateSubjectName = {},
+            updateClassRoom = {},
+            updateTeacher = {},
+            registerSubject = {},
+        )
     }
 }

--- a/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Icon
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -24,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -105,6 +107,7 @@ fun AddSubjectContent(
         OutlinedTextField(
             value = subjectName,
             onValueChange = { updateSubjectName(it) },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
             label = {
                 Text(text = stringResource(id = R.string.subject_name))
             },
@@ -113,6 +116,7 @@ fun AddSubjectContent(
         OutlinedTextField(
             value = classRoom,
             onValueChange = { updateClassRoom(it) },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
             label = {
                 Text(text = stringResource(id = R.string.class_room))
             },
@@ -121,6 +125,7 @@ fun AddSubjectContent(
         OutlinedTextField(
             value = teacher,
             onValueChange = { updateTeacher(it) },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
             label = {
                 Text(text = stringResource(id = R.string.teacher))
             },

--- a/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
@@ -34,23 +34,22 @@ import com.example.timetable.R
 fun AddSubjectScreen(
     modifier: Modifier = Modifier,
     viewModel: AddSubjectViewModel = hiltViewModel(),
-    transitionToBackStack : () -> Unit,
+    transitionToBackStack: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    Column(
-    ) {
+    Column() {
         Row(
             modifier = modifier.padding(8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ){
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             IconButton(onClick = {
                 transitionToBackStack()
             }) {
                 Icon(
                     Icons.Default.Close,
                     null,
-                    modifier = modifier.weight(.1f)
+                    modifier = modifier.weight(.1f),
                 )
             }
             Spacer(modifier = modifier.weight(.3f))
@@ -59,7 +58,7 @@ fun AddSubjectScreen(
                 onClick = {
                     viewModel.addSubject()
                     transitionToBackStack()
-                          },
+                },
             ) {
                 Text(
                     text = "科目登録",
@@ -75,7 +74,6 @@ fun AddSubjectScreen(
             updateTeacher = viewModel::updateTeacher,
         )
     }
-
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -89,7 +87,6 @@ fun AddSubjectContent(
     updateClassRoom: (String) -> Unit,
     updateTeacher: (String) -> Unit,
 ) {
-
     val focusRequester = remember { FocusRequester() }
 
     Column(
@@ -131,7 +128,7 @@ fun AddSubjectContent(
         )
     }
 
-    LaunchedEffect(Unit){
+    LaunchedEffect(Unit) {
         focusRequester.requestFocus()
     }
 }

--- a/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
@@ -1,7 +1,13 @@
 package com.example.timetable.ui.addSubject
 
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment

--- a/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
@@ -1,10 +1,16 @@
 package com.example.timetable.ui.addSubject
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
@@ -27,15 +33,40 @@ fun AddSubjectScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    AddSubjectContent(
-        subjectName = uiState.subjectName,
-        classRoom = uiState.classRoom,
-        teacher = uiState.teacher,
-        updateSubjectName = viewModel::updateSubjectName,
-        updateClassRoom = viewModel::updateClassRoom,
-        updateTeacher = viewModel::updateTeacher,
-        registerSubject = viewModel::addSubject,
-    )
+    Column(
+    ) {
+        Row(
+            modifier = modifier.padding(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ){
+            IconButton(onClick = { /*TODO*/ }) {
+                Icon(
+                    Icons.Default.Close,
+                    null,
+                    modifier = modifier.weight(.1f)
+                )
+            }
+            Spacer(modifier = modifier.weight(.3f))
+
+            Button(
+                onClick = { /*TODO*/ },
+            ) {
+                Text(
+                    text = "科目登録",
+                )
+            }
+        }
+        AddSubjectContent(
+            subjectName = uiState.subjectName,
+            classRoom = uiState.classRoom,
+            teacher = uiState.teacher,
+            updateSubjectName = viewModel::updateSubjectName,
+            updateClassRoom = viewModel::updateClassRoom,
+            updateTeacher = viewModel::updateTeacher,
+            registerSubject = viewModel::addSubject,
+        )
+    }
+
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -87,17 +118,6 @@ fun AddSubjectContent(
             },
             modifier = textFieldModifier,
         )
-
-        Button(
-            onClick = {
-                registerSubject()
-            },
-            modifier = modifier
-                .align(Alignment.End)
-                .padding(8.dp),
-        ) {
-            Text(text = "科目登録")
-        }
     }
 }
 

--- a/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
@@ -16,9 +16,13 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -85,6 +89,9 @@ fun AddSubjectContent(
     updateClassRoom: (String) -> Unit,
     updateTeacher: (String) -> Unit,
 ) {
+
+    val focusRequester = remember { FocusRequester() }
+
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -104,7 +111,7 @@ fun AddSubjectContent(
             label = {
                 Text(text = stringResource(id = R.string.subject_name))
             },
-            modifier = textFieldModifier,
+            modifier = textFieldModifier.focusRequester(focusRequester),
         )
         OutlinedTextField(
             value = classRoom,
@@ -122,6 +129,10 @@ fun AddSubjectContent(
             },
             modifier = textFieldModifier,
         )
+    }
+
+    LaunchedEffect(Unit){
+        focusRequester.requestFocus()
     }
 }
 

--- a/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
@@ -30,6 +30,7 @@ import com.example.timetable.R
 fun AddSubjectScreen(
     modifier: Modifier = Modifier,
     viewModel: AddSubjectViewModel = hiltViewModel(),
+    transitionToBackStack : () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -39,7 +40,9 @@ fun AddSubjectScreen(
             modifier = modifier.padding(8.dp),
             verticalAlignment = Alignment.CenterVertically
         ){
-            IconButton(onClick = { /*TODO*/ }) {
+            IconButton(onClick = {
+                transitionToBackStack()
+            }) {
                 Icon(
                     Icons.Default.Close,
                     null,
@@ -49,7 +52,9 @@ fun AddSubjectScreen(
             Spacer(modifier = modifier.weight(.3f))
 
             Button(
-                onClick = { /*TODO*/ },
+                onClick = {
+                          viewModel::addSubject
+                          },
             ) {
                 Text(
                     text = "科目登録",
@@ -63,7 +68,6 @@ fun AddSubjectScreen(
             updateSubjectName = viewModel::updateSubjectName,
             updateClassRoom = viewModel::updateClassRoom,
             updateTeacher = viewModel::updateTeacher,
-            registerSubject = viewModel::addSubject,
         )
     }
 
@@ -79,7 +83,6 @@ fun AddSubjectContent(
     updateSubjectName: (String) -> Unit,
     updateClassRoom: (String) -> Unit,
     updateTeacher: (String) -> Unit,
-    registerSubject: () -> Unit,
 ) {
     Column(
         modifier = modifier
@@ -132,7 +135,6 @@ fun PreviewAddSubject() {
             updateSubjectName = {},
             updateClassRoom = {},
             updateTeacher = {},
-            registerSubject = {},
         )
     }
 }

--- a/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
@@ -53,7 +53,8 @@ fun AddSubjectScreen(
 
             Button(
                 onClick = {
-                          viewModel::addSubject
+                    viewModel.addSubject()
+                    transitionToBackStack()
                           },
             ) {
                 Text(

--- a/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
@@ -11,13 +11,11 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.timetable.R
-import com.example.timetable.model.source.Subject
-import com.example.timetable.ui.manageSubjects.DisplaySubjects
 
 @Composable
 fun AddSubjectScreen(
     modifier: Modifier = Modifier,
-    viewModel: MainViewModel = hiltViewModel(),
+    viewModel: AddSubjectViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -30,10 +28,6 @@ fun AddSubjectScreen(
             updateClassRoom = viewModel::updateClassRoom,
             updateTeacher = viewModel::updateTeacher,
             registerSubject = viewModel::addSubject,
-        )
-
-        DisplaySubjects(
-            subjects = uiState.subjects,
         )
     }
 }
@@ -99,31 +93,4 @@ fun AddSubjectContent(
             Text(text = "科目登録")
         }
     }
-}
-
-@Composable
-fun SubjectContent(
-    modifier: Modifier = Modifier,
-    subject: Subject,
-) {
-    Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(4.dp),
-        content = {
-            Box(modifier = modifier.padding(vertical = 4.dp, horizontal = 8.dp)) {
-                Column() {
-                    Text(
-                        text = subject.subjectName,
-                        modifier = modifier.padding(8.dp),
-                    )
-                    Row() {
-                        Text(text = subject.classRoom ?: "")
-                        Spacer(modifier = modifier.width(16.dp))
-                        Text(text = subject.teacher ?: "")
-                    }
-                }
-            }
-        },
-    )
 }

--- a/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectScreen.kt
@@ -1,20 +1,7 @@
 package com.example.timetable.ui.addSubject
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -25,6 +12,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.timetable.R
 import com.example.timetable.model.source.Subject
+import com.example.timetable.ui.manageSubjects.DisplaySubjects
 
 @Composable
 fun AddSubjectScreen(
@@ -109,28 +97,6 @@ fun AddSubjectContent(
                 .padding(8.dp),
         ) {
             Text(text = "科目登録")
-        }
-    }
-}
-
-@Composable
-fun DisplaySubjects(
-    modifier: Modifier = Modifier,
-    subjects: List<Subject>,
-) {
-    Column(
-        modifier = modifier.padding(8.dp),
-    ) {
-        Text(
-            text = "登録された科目一覧",
-            style = MaterialTheme.typography.titleLarge,
-        )
-        LazyColumn(
-            modifier = modifier.padding(8.dp),
-        ) {
-            items(subjects) {
-                SubjectContent(subject = it)
-            }
         }
     }
 }

--- a/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectViewModel.kt
+++ b/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectViewModel.kt
@@ -12,23 +12,20 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-data class MainUiState(
+data class AddSubjectUiState(
     val subjectName: String = "",
     val classRoom: String = "",
     val teacher: String = "",
-    val subjects: List<Subject> = emptyList(),
 )
 
 @HiltViewModel
-class MainViewModel @Inject constructor(
+class AddSubjectViewModel @Inject constructor(
     private val timeTableRepository: TimeTableRepository,
 ) : ViewModel() {
-    private val _uiState = MutableStateFlow(MainUiState())
-    val uiState: StateFlow<MainUiState> = _uiState
+    private val TAG = "AddSubjectViewModel"
 
-    init {
-        getAllSubject()
-    }
+    private val _uiState = MutableStateFlow(AddSubjectUiState())
+    val uiState: StateFlow<AddSubjectUiState> = _uiState
 
     fun updateSubjectName(newSubjectName: String) {
         _uiState.update {
@@ -48,21 +45,7 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    fun getAllSubject() = viewModelScope.launch {
-        val TAG = "GET_SUBJECT"
-        try {
-            timeTableRepository.getSubjects().collect { subjects ->
-                _uiState.update {
-                    it.copy(subjects = subjects)
-                }
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Failure Get Subject with $e")
-        }
-    }
     fun addSubject() = viewModelScope.launch {
-        val TAG = "ADD_SUBJECT"
-
         try {
             val newSubject = Subject(
                 subjectName = _uiState.value.subjectName.let {

--- a/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectViewModel.kt
+++ b/app/src/main/java/com/example/timetable/ui/addSubject/AddSubjectViewModel.kt
@@ -59,7 +59,7 @@ class AddSubjectViewModel @Inject constructor(
                 teacher = _uiState.value.teacher,
                 subjectColor = "",
             )
-            Log.i(TAG, "Success Insert Subject")
+            Log.d(TAG, "Success Insert Subject")
             timeTableRepository.addSubject(newSubject)
         } catch (e: CollectSubjectError) {
             Log.e(TAG, "Failure Insert Subject with $e")

--- a/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsScreen.kt
@@ -1,0 +1,11 @@
+package com.example.timetable.ui.manageSubjects
+
+import androidx.compose.runtime.Composable
+import java.lang.reflect.Modifier
+
+@Composable
+fun ManageSubjectsScreen(
+    modifier: Modifier
+) {
+
+}

--- a/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsScreen.kt
@@ -86,22 +86,22 @@ fun SubjectContent(
         content = {
             Box(modifier = modifier.padding(vertical = 4.dp, horizontal = 8.dp)) {
                 Column(
-                    modifier = modifier.padding(4.dp)
+                    modifier = modifier.padding(4.dp),
                 ) {
                     Text(
                         text = subject.subjectName,
-                        style = MaterialTheme.typography.titleMedium
+                        style = MaterialTheme.typography.titleMedium,
                     )
                     Row() {
                         val style = MaterialTheme.typography.bodyMedium
                         Text(
                             text = subject.classRoom ?: "",
-                            style = style
+                            style = style,
                         )
                         Spacer(modifier = modifier.width(16.dp))
                         Text(
                             text = subject.teacher ?: "",
-                            style = style
+                            style = style,
                         )
                     }
                 }
@@ -138,7 +138,7 @@ fun PreviewSubjectContentWhenOnlyName() {
         subjectName = "科目名",
         classRoom = null,
         teacher = null,
-        subjectColor = ""
+        subjectColor = "",
     )
     SubjectContent(subject = subject)
 }
@@ -151,7 +151,7 @@ fun PreviewSubjectContentWhenAllInfo() {
         subjectName = "科目名",
         classRoom = "教室名",
         teacher = "担当教員",
-        subjectColor = ""
+        subjectColor = "",
     )
     SubjectContent(subject = subject)
 }

--- a/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsScreen.kt
@@ -9,12 +9,19 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Icon
+import androidx.compose.material.Scaffold
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Card
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -26,7 +33,19 @@ fun ManageSubjectsScreen(
     viewModel: ManageSubjectsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    DisplaySubjects(subjects = uiState.subjects)
+
+    Scaffold(
+        floatingActionButton = {
+            FloatingActionButton(onClick = { /*TODO*/ }) {
+                Icon(Icons.Default.Add, null)
+            }
+        }
+    ) {
+        DisplaySubjects(
+            subjects = uiState.subjects,
+            modifier = modifier.padding(it)
+        )
+    }
 }
 
 @Composable
@@ -40,6 +59,7 @@ fun DisplaySubjects(
         Text(
             text = "登録された科目一覧",
             style = MaterialTheme.typography.titleLarge,
+            modifier = modifier.padding(4.dp)
         )
         LazyColumn(
             modifier = modifier.padding(8.dp),
@@ -76,4 +96,24 @@ fun SubjectContent(
             }
         },
     )
+}
+
+@Preview
+@Composable
+fun PreviewDisplaySubject() {
+    val subjects = mutableListOf<Subject>()
+
+    for(i in 0..10){
+        val subject = Subject(
+            id = i,
+            subjectName = "科目：$i",
+            classRoom = null,
+            teacher = null,
+            subjectColor = ""
+        )
+        subjects.add(subject)
+    }
+    Surface() {
+        DisplaySubjects(subjects = subjects)
+    }
 }

--- a/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsScreen.kt
@@ -31,12 +31,15 @@ import com.example.timetable.model.source.Subject
 fun ManageSubjectsScreen(
     modifier: Modifier = Modifier,
     viewModel: ManageSubjectsViewModel = hiltViewModel(),
+    transitionToAddSubject:() -> Unit = {},
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     Scaffold(
         floatingActionButton = {
-            FloatingActionButton(onClick = { /*TODO*/ }) {
+            FloatingActionButton(
+                onClick = { transitionToAddSubject() }
+            ) {
                 Icon(Icons.Default.Add, null)
             }
         }

--- a/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsScreen.kt
@@ -1,9 +1,9 @@
 package com.example.timetable.ui.manageSubjects
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -13,7 +13,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.timetable.model.source.Subject
-import com.example.timetable.ui.addSubject.SubjectContent
 
 @Composable
 fun ManageSubjectsScreen(
@@ -44,4 +43,32 @@ fun DisplaySubjects(
             }
         }
     }
+}
+
+
+@Composable
+fun SubjectContent(
+    modifier: Modifier = Modifier,
+    subject: Subject,
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(4.dp),
+        content = {
+            Box(modifier = modifier.padding(vertical = 4.dp, horizontal = 8.dp)) {
+                Column() {
+                    Text(
+                        text = subject.subjectName,
+                        modifier = modifier.padding(8.dp),
+                    )
+                    Row() {
+                        Text(text = subject.classRoom ?: "")
+                        Spacer(modifier = modifier.width(16.dp))
+                        Text(text = subject.teacher ?: "")
+                    }
+                }
+            }
+        },
+    )
 }

--- a/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsScreen.kt
@@ -1,6 +1,12 @@
 package com.example.timetable.ui.manageSubjects
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
@@ -44,7 +50,6 @@ fun DisplaySubjects(
         }
     }
 }
-
 
 @Composable
 fun SubjectContent(

--- a/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsScreen.kt
@@ -61,7 +61,7 @@ fun DisplaySubjects(
     ) {
         Text(
             text = "登録された科目一覧",
-            style = MaterialTheme.typography.titleLarge,
+            style = MaterialTheme.typography.headlineSmall,
             modifier = modifier.padding(4.dp),
         )
         LazyColumn(
@@ -85,15 +85,24 @@ fun SubjectContent(
             .padding(4.dp),
         content = {
             Box(modifier = modifier.padding(vertical = 4.dp, horizontal = 8.dp)) {
-                Column() {
+                Column(
+                    modifier = modifier.padding(4.dp)
+                ) {
                     Text(
                         text = subject.subjectName,
-                        modifier = modifier.padding(8.dp),
+                        style = MaterialTheme.typography.titleMedium
                     )
                     Row() {
-                        Text(text = subject.classRoom ?: "")
+                        val style = MaterialTheme.typography.bodyMedium
+                        Text(
+                            text = subject.classRoom ?: "",
+                            style = style
+                        )
                         Spacer(modifier = modifier.width(16.dp))
-                        Text(text = subject.teacher ?: "")
+                        Text(
+                            text = subject.teacher ?: "",
+                            style = style
+                        )
                     }
                 }
             }
@@ -119,4 +128,30 @@ fun PreviewDisplaySubject() {
     Surface() {
         DisplaySubjects(subjects = subjects)
     }
+}
+
+@Preview
+@Composable
+fun PreviewSubjectContentWhenOnlyName() {
+    val subject = Subject(
+        id = 0,
+        subjectName = "科目名",
+        classRoom = null,
+        teacher = null,
+        subjectColor = ""
+    )
+    SubjectContent(subject = subject)
+}
+
+@Preview
+@Composable
+fun PreviewSubjectContentWhenAllInfo() {
+    val subject = Subject(
+        id = 0,
+        subjectName = "科目名",
+        classRoom = "教室名",
+        teacher = "担当教員",
+        subjectColor = ""
+    )
+    SubjectContent(subject = subject)
 }

--- a/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsScreen.kt
@@ -31,22 +31,22 @@ import com.example.timetable.model.source.Subject
 fun ManageSubjectsScreen(
     modifier: Modifier = Modifier,
     viewModel: ManageSubjectsViewModel = hiltViewModel(),
-    transitionToAddSubject:() -> Unit = {},
+    transitionToAddSubject: () -> Unit = {},
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     Scaffold(
         floatingActionButton = {
             FloatingActionButton(
-                onClick = { transitionToAddSubject() }
+                onClick = { transitionToAddSubject() },
             ) {
                 Icon(Icons.Default.Add, null)
             }
-        }
+        },
     ) {
         DisplaySubjects(
             subjects = uiState.subjects,
-            modifier = modifier.padding(it)
+            modifier = modifier.padding(it),
         )
     }
 }
@@ -62,7 +62,7 @@ fun DisplaySubjects(
         Text(
             text = "登録された科目一覧",
             style = MaterialTheme.typography.titleLarge,
-            modifier = modifier.padding(4.dp)
+            modifier = modifier.padding(4.dp),
         )
         LazyColumn(
             modifier = modifier.padding(8.dp),
@@ -106,13 +106,13 @@ fun SubjectContent(
 fun PreviewDisplaySubject() {
     val subjects = mutableListOf<Subject>()
 
-    for(i in 0..10){
+    for (i in 0..10) {
         val subject = Subject(
             id = i,
             subjectName = "科目：$i",
             classRoom = null,
             teacher = null,
-            subjectColor = ""
+            subjectColor = "",
         )
         subjects.add(subject)
     }

--- a/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsScreen.kt
+++ b/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsScreen.kt
@@ -1,11 +1,47 @@
 package com.example.timetable.ui.manageSubjects
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import java.lang.reflect.Modifier
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.timetable.model.source.Subject
+import com.example.timetable.ui.addSubject.SubjectContent
 
 @Composable
 fun ManageSubjectsScreen(
-    modifier: Modifier
+    modifier: Modifier = Modifier,
+    viewModel: ManageSubjectsViewModel = hiltViewModel(),
 ) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    DisplaySubjects(subjects = uiState.subjects)
+}
 
+@Composable
+fun DisplaySubjects(
+    modifier: Modifier = Modifier,
+    subjects: List<Subject>,
+) {
+    Column(
+        modifier = modifier.padding(8.dp),
+    ) {
+        Text(
+            text = "登録された科目一覧",
+            style = MaterialTheme.typography.titleLarge,
+        )
+        LazyColumn(
+            modifier = modifier.padding(8.dp),
+        ) {
+            items(subjects) {
+                SubjectContent(subject = it)
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsViewModel.kt
+++ b/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsViewModel.kt
@@ -1,0 +1,22 @@
+package com.example.timetable.ui.manageSubjects
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import com.example.timetable.model.repository.TimeTableRepository
+import com.example.timetable.model.source.Subject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import javax.inject.Inject
+
+data class ManageSubjectUiState(
+    val subjects: List<Subject> = emptyList(),
+    )
+
+@HiltViewModel
+class ManageSubjectsViewModel @Inject constructor(
+    private val timeTableRepository: TimeTableRepository
+): ViewModel() {
+    private val _uiState = MutableStateFlow(ManageSubjectUiState())
+    val uiState = _uiState
+}

--- a/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsViewModel.kt
+++ b/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsViewModel.kt
@@ -1,12 +1,14 @@
 package com.example.timetable.ui.manageSubjects
 
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.mutableStateOf
+import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.timetable.model.repository.TimeTableRepository
 import com.example.timetable.model.source.Subject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 data class ManageSubjectUiState(
@@ -17,6 +19,24 @@ data class ManageSubjectUiState(
 class ManageSubjectsViewModel @Inject constructor(
     private val timeTableRepository: TimeTableRepository
 ): ViewModel() {
+   private val TAG = "ManageSubjectsViewModel"
+
     private val _uiState = MutableStateFlow(ManageSubjectUiState())
     val uiState = _uiState
+
+    init {
+        getAllSubject()
+    }
+
+    private fun getAllSubject() = viewModelScope.launch {
+        try {
+            timeTableRepository.getSubjects().collect { subjects ->
+                _uiState.update {
+                    it.copy(subjects = subjects)
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failure Get Subject with $e")
+        }
+    }
 }

--- a/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsViewModel.kt
+++ b/app/src/main/java/com/example/timetable/ui/manageSubjects/ManageSubjectsViewModel.kt
@@ -13,13 +13,13 @@ import javax.inject.Inject
 
 data class ManageSubjectUiState(
     val subjects: List<Subject> = emptyList(),
-    )
+)
 
 @HiltViewModel
 class ManageSubjectsViewModel @Inject constructor(
-    private val timeTableRepository: TimeTableRepository
-): ViewModel() {
-   private val TAG = "ManageSubjectsViewModel"
+    private val timeTableRepository: TimeTableRepository,
+) : ViewModel() {
+    private val TAG = "ManageSubjectsViewModel"
 
     private val _uiState = MutableStateFlow(ManageSubjectUiState())
     val uiState = _uiState

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
 
     <string name="timetable_title">時間割り</string>
     <string name="subjects_title">科目管理</string>
+    <string name="add_subjects_title">科目の追加</string>
 
     <string name="registered_subjects">登録された科目一覧</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,6 @@
 
     <string name="timetable_title">時間割り</string>
     <string name="subjects_title">科目管理</string>
+
+    <string name="registered_subjects">登録された科目一覧</string>
 </resources>


### PR DESCRIPTION
## マージの目的
科目追加画面を科目管理画面と分離する．
- 対応するIssue: #14 

## 変更内容
- 科目追加画面を科目管理画面と分離する．
- 科目管理画面からFABを使って科目追加画面に遷移する．
- 

## 確認内容
- fuga

## 参考画像
- なくても良い
